### PR TITLE
Avoid duplicating output.

### DIFF
--- a/fractalai/swarm_wave.py
+++ b/fractalai/swarm_wave.py
@@ -371,9 +371,8 @@ class SwarmWave:
                     print(self)
             except KeyboardInterrupt:
                 break
-
-        print(self)
         clear_output(True)
+        print(self)
 
     def recover_game(self, index=None) -> list:
         """


### PR DESCRIPTION
At the end of the game, output was duplicated.